### PR TITLE
Remove unnecessary upper-bound constraints

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
 inspired by Haskell's Traversable typeclass.  It sits on top of Jane Street's
 Base library and ecosystem.")
  (depends
-  (ocaml (and (>= 4.07) (< 4.11)))
-  (dune (and (>= 2.0) (< 3.0)))
+  (ocaml (>= 4.07))
+  (dune (>= 2.0))
   (ppx_jane (and (>= v0.12.0) (< v0.15.0)))
   (base (and (>= v0.12.0) (< v0.15.0)))))

--- a/travesty.opam
+++ b/travesty.opam
@@ -12,8 +12,8 @@ homepage: "https://MattWindsor91.github.io/travesty/"
 doc: "https://MattWindsor91.github.io/travesty/"
 bug-reports: "https://github.com/MattWindsor91/travesty/issues"
 depends: [
-  "ocaml" {>= "4.07" & < "4.11"}
-  "dune" {>= "2.0" & < "3.0"}
+  "ocaml" {>= "4.07"}
+  "dune" {>= "2.0"}
   "ppx_jane" {>= "v0.12.0" & < "v0.15.0"}
   "base" {>= "v0.12.0" & < "v0.15.0"}
 ]


### PR DESCRIPTION
Will looking for packages that weren't compatible with OCaml 4.11 I stubbled upon your library which seems to be compiling fine if we remove the constraints. To me as an opam-repository maintainer, these constraints seem a bit excessive if you don't rely on `compiler-libs` or other internals linked to the compiler. Furthermore for both the compiler and dune, we do checks before each major updates to see if every packages compiles correctly or not, so on opam-repository side we got you covered.